### PR TITLE
Create explicit functions for each PAL protocol

### DIFF
--- a/include/mqtt_pal.h
+++ b/include/mqtt_pal.h
@@ -92,13 +92,25 @@ extern "C" {
     #ifndef MQTT_USE_CUSTOM_SOCKET_HANDLE
         #ifdef MQTT_USE_MBEDTLS
             struct mbedtls_ssl_context;
-            typedef struct mbedtls_ssl_context *mqtt_pal_socket_handle;
+            typedef struct mbedtls_ssl_context *mqtt_pal_mbedtls_socket_handle;
+            #define MQTT_PAL_ENABLE_MBEDTLS
+            #define mqtt_pal_socket_handle mqtt_pal_mbedtls_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_mbedtls_sendall
+            #define mqtt_pal_recvall mqtt_pal_mbedtls_recvall
         #elif defined(MQTT_USE_WOLFSSL)
             #include <wolfssl/ssl.h>
-            typedef WOLFSSL* mqtt_pal_socket_handle;
+            typedef WOLFSSL* mqtt_pal_wolfssl_socket_handle;
+            #define MQTT_PAL_ENABLE_WOLFSSL
+            #define mqtt_pal_socket_handle mqtt_pal_wolfssl_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_wolfssl_sendall
+            #define mqtt_pal_recvall mqtt_pal_wolfssl_recvall
         #elif defined(MQTT_USE_BIO)
             #include <openssl/bio.h>
-            typedef BIO* mqtt_pal_socket_handle;
+            typedef BIO* mqtt_pal_bio_socket_handle;
+            #define MQTT_PAL_ENABLE_BIO
+            #define mqtt_pal_socket_handle mqtt_pal_bio_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_bio_sendall
+            #define mqtt_pal_recvall mqtt_pal_bio_recvall
         #elif defined(MQTT_USE_BEARSSL)
             #include <bearssl.h>
 
@@ -113,9 +125,17 @@ extern "C" {
                 int (*low_write)(void *write_context, const unsigned char *buf, size_t len);
             } bearssl_context;
 
-            typedef bearssl_context* mqtt_pal_socket_handle;
+            typedef bearssl_context* mqtt_pal_bearssl_socket_handle;
+            #define MQTT_PAL_ENABLE_BEARSSL
+            #define mqtt_pal_socket_handle mqtt_pal_bearssl_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_bearssl_sendall
+            #define mqtt_pal_recvall mqtt_pal_bearssl_recvall
         #else
-            typedef int mqtt_pal_socket_handle;
+            typedef int mqtt_pal_tcp_socket_handle;
+            #define MQTT_PAL_ENABLE_TCP
+            #define mqtt_pal_socket_handle mqtt_pal_tcp_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_tcp_sendall
+            #define mqtt_pal_recvall mqtt_pal_tcp_recvall
         #endif
     #endif
 #elif defined(_MSC_VER)
@@ -142,13 +162,47 @@ extern "C" {
     #ifndef MQTT_USE_CUSTOM_SOCKET_HANDLE
         #ifdef MQTT_USE_BIO
             #include <openssl/bio.h>
-            typedef BIO* mqtt_pal_socket_handle;
+            typedef BIO* mqtt_pal_bio_socket_handle;
+            #define MQTT_PAL_ENABLE_BIO
+            #define mqtt_pal_socket_handle mqtt_pal_bio_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_bio_sendall
+            #define mqtt_pal_recvall mqtt_pal_bio_recvall
         #else
-            typedef SOCKET mqtt_pal_socket_handle;
+            typedef SOCKET mqtt_pal_tcp_socket_handle;
+            #define MQTT_PAL_ENABLE_TCP
+            #define mqtt_pal_socket_handle mqtt_pal_tcp_socket_handle
+            #define mqtt_pal_sendall mqtt_pal_tcp_sendall
+            #define mqtt_pal_recvall mqtt_pal_tcp_recvall
         #endif
     #endif
 
 #endif
+
+#ifdef MQTT_PAL_ENABLE_MBEDTLS
+ssize_t mqtt_pal_mbedtls_sendall(mqtt_pal_mbedtls_socket_handle fd, const void* buf, size_t len, int flags);
+ssize_t mqtt_pal_mbedtls_recvall(mqtt_pal_mbedtls_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
+
+#ifdef MQTT_PAL_ENABLE_WOLFSSL
+ssize_t mqtt_pal_wolfssl_sendall(mqtt_pal_wolfssl_socket_handle fd, const void* buf, size_t len, int flags);
+ssize_t mqtt_pal_wolfssl_recvall(mqtt_pal_wolfssl_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
+
+#ifdef MQTT_PAL_ENABLE_BIO
+ssize_t mqtt_pal_bio_sendall(mqtt_pal_bio_socket_handle fd, const void* buf, size_t len, int flags);
+ssize_t mqtt_pal_bio_recvall(mqtt_pal_bio_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
+
+#ifdef MQTT_PAL_ENABLE_BEARSSL
+ssize_t mqtt_pal_bearssl_sendall(mqtt_pal_bearssl_socket_handle fd, const void* buf, size_t len, int flags);
+ssize_t mqtt_pal_bearssl_recvall(mqtt_pal_bearssl_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
+
+#ifdef MQTT_PAL_ENABLE_TCP
+ssize_t mqtt_pal_tcp_sendall(mqtt_pal_tcp_socket_handle fd, const void* buf, size_t len, int flags);
+ssize_t mqtt_pal_tcp_recvall(mqtt_pal_tcp_socket_handle fd, void* buf, size_t bufsz, int flags);
+#endif
+
 
 /**
  * @brief Sends all the bytes in a buffer.

--- a/src/mqtt_pal.c
+++ b/src/mqtt_pal.c
@@ -32,10 +32,10 @@ SOFTWARE.
  */
 
 
-#ifdef MQTT_USE_MBEDTLS
+#ifdef MQTT_PAL_ENABLE_MBEDTLS
 #include <mbedtls/ssl.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_mbedtls_sendall(mqtt_pal_mbedtls_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         int rv = mbedtls_ssl_write(fd, buf + sent, len - sent);
@@ -59,7 +59,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_mbedtls_recvall(mqtt_pal_mbedtls_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void *const start = buf;
     int rv;
     do {
@@ -99,10 +99,12 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return buf - start;
 }
 
-#elif defined(MQTT_USE_WOLFSSL)
+#endif
+
+#if defined(MQTT_PAL_ENABLE_WOLFSSL)
 #include <wolfssl/ssl.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_wolfssl_sendall(mqtt_pal_wolfssl_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while (sent < len) {
         int tmp = wolfSSL_write(fd, buf + sent, (int)(len - sent));
@@ -118,7 +120,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return (ssize_t)sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_wolfssl_recvall(mqtt_pal_wolfssl_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void* const start = buf;
     int tmp;
     do {
@@ -137,7 +139,9 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return (ssize_t)(buf - start);
 }
 
-#elif defined(MQTT_USE_BEARSSL)
+#endif
+
+#if defined(MQTT_PAL_ENABLE_BEARSSL)
 #include <bearssl.h>
 #include <memory.h>
 
@@ -182,7 +186,7 @@ static int do_rec_data(mqtt_pal_socket_handle fd, unsigned int status) {
     return MQTT_OK;
 }
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_bearssl_sendall(mqtt_pal_bearssl_socket_handle fd, const void* buf, size_t len, int flags) {
     int rc = MQTT_OK;
     uint8_t *buffer;
     size_t length;
@@ -228,7 +232,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return len;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_bearssl_recvall(mqtt_pal_bearssl_socket_handle fd, void* buf, size_t bufsz, int flags) {
     int rc = MQTT_OK;
     uint8_t *buffer;
     size_t length;
@@ -266,12 +270,14 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return bufsz - remaining_bytes;
 }
 
-#elif defined(MQTT_USE_BIO)
+#endif
+
+#if defined(MQTT_PAL_ENABLE_BIO)
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_bio_sendall(mqtt_pal_bio_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         int tmp = BIO_write(fd, (const char*)buf + sent, len - sent);
@@ -285,7 +291,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_bio_recvall(mqtt_pal_bio_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const char* const start = buf;
     char* bufptr = buf;
     int rv;
@@ -304,11 +310,15 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
     return (ssize_t)(bufptr - start);
 }
 
-#elif defined(__unix__) || defined(__APPLE__) || defined(__NuttX__)
+#endif
+
+#if defined(MQTT_PAL_ENABLE_TCP)
+
+#if defined(__unix__) || defined(__APPLE__) || defined(__NuttX__)
 
 #include <errno.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_tcp_sendall(mqtt_pal_tcp_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         ssize_t tmp = send(fd, buf + sent, len - sent, flags);
@@ -323,7 +333,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_tcp_recvall(mqtt_pal_tcp_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const void *const start = buf;
     ssize_t rv;
     do {
@@ -345,7 +355,7 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
 
 #include <errno.h>
 
-ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len, int flags) {
+ssize_t mqtt_pal_tcp_sendall(mqtt_pal_tcp_socket_handle fd, const void* buf, size_t len, int flags) {
     size_t sent = 0;
     while(sent < len) {
         ssize_t tmp = send(fd, (char*)buf + sent, len - sent, flags);
@@ -357,7 +367,7 @@ ssize_t mqtt_pal_sendall(mqtt_pal_socket_handle fd, const void* buf, size_t len,
     return sent;
 }
 
-ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int flags) {
+ssize_t mqtt_pal_tcp_recvall(mqtt_pal_tcp_socket_handle fd, void* buf, size_t bufsz, int flags) {
     const char *const start = buf;
     ssize_t rv;
     do {
@@ -380,7 +390,9 @@ ssize_t mqtt_pal_recvall(mqtt_pal_socket_handle fd, void* buf, size_t bufsz, int
 
 #else
 
-#error No PAL!
+#error No TCP PAL!
+
+#endif
 
 #endif
 


### PR DESCRIPTION
Functions for each protocol are created, so that they can
be used even when MQTT_USE_CUSTOM_SOCKET_HANDLE is defined.

The functions and types are mapped to default names in case
MQTT_USE_CUSTOM_SOCKET_HANDLE is not used, so maintaining the
default functionality.